### PR TITLE
gralloc: Conditionally revert a63c31599d2f5e43a59165149534bc5248283a45

### DIFF
--- a/gralloc/gr_buf_mgr.cpp
+++ b/gralloc/gr_buf_mgr.cpp
@@ -822,8 +822,15 @@ void BufferManager::RegisterHandleLocked(const private_handle_t *hnd, int ion_ha
   auto buffer = std::make_shared<Buffer>(hnd, ion_handle, ion_handle_meta);
 
   if (hnd->base_metadata) {
+#ifndef GRALLOC_HANDLE_HAS_RESERVED_SIZE
+    auto metadata = reinterpret_cast<MetaData_t *>(hnd->base_metadata);
+#endif
 #ifdef METADATA_V2
+#ifdef GRALLOC_HANDLE_HAS_RESERVED_SIZE
     buffer->reserved_size = hnd->reserved_size;
+#else
+    buffer->reserved_size = metadata->reservedSize;
+#endif
     if (buffer->reserved_size > 0) {
       buffer->reserved_region_ptr =
           reinterpret_cast<void *>(hnd->base_metadata + sizeof(MetaData_t));


### PR DESCRIPTION
Revert this commit if gralloc handle does not have reserved_size field.

This conditionally reverts: "Gralloc: Use handle reserved size while importing buffer", some devices do not have reserved_size field, so let's just keep it for these devices.